### PR TITLE
Add LinkML 1.4 compatibility for CKAN 2.9 production

### DIFF
--- a/ckanext/dcat/profiles/dcat_ap_plus.py
+++ b/ckanext/dcat/profiles/dcat_ap_plus.py
@@ -157,6 +157,28 @@ def _prepare_linkml_14_schema_dir(schema_dir):
 
     shutil.copytree(schema_dir, tmp_schema_dir)
 
+    # chem_dcat_ap.yaml imports dcat_ap_plus.
+    # On the test-server branch, dcat_ap_plus.yaml may not exist locally,
+    # so create a sanitized local copy from the remote PURL.
+    local_dcat_ap_plus = os.path.join(tmp_schema_dir, "dcat_ap_plus.yaml")
+    if not os.path.exists(local_dcat_ap_plus):
+        try:
+            resp = requests.get(
+                "https://w3id.org/nfdi-de/dcat-ap-plus/",
+                headers={"Accept": "application/yaml, text/yaml"},
+                timeout=10
+            )
+            resp.raise_for_status()
+
+            dcat_ap_plus_text = _strip_linkml_18_keywords_for_linkml_14(resp.text)
+
+            with open(local_dcat_ap_plus, "w") as fh:
+                fh.write(dcat_ap_plus_text)
+
+            log.info("Created sanitized local dcat_ap_plus.yaml for LinkML 1.4.0")
+        except Exception as e:
+            log.error("Failed to create local dcat_ap_plus.yaml: %s", e)
+
     for root, dirs, files in os.walk(tmp_schema_dir):
         for filename in files:
             if not filename.endswith((".yaml", ".yml")):

--- a/ckanext/dcat/profiles/dcat_ap_plus.py
+++ b/ckanext/dcat/profiles/dcat_ap_plus.py
@@ -1,5 +1,6 @@
 import json
 import os
+import tempfile
 from decimal import Decimal, DecimalException
 import requests
 from rdflib import term, URIRef, BNode, Literal, Graph
@@ -93,32 +94,68 @@ class Helpers(object):
 
         Returns: SchemaView instance or None
         """
+        # 1. Check Memory Cache
         if schema_name in _SCHEMA_VIEW_CACHE:
             return _SCHEMA_VIEW_CACHE[schema_name]
 
-        current_dir = os.path.dirname(os.path.abspath(__file__))
-        local_yaml_path = os.path.normpath(
-            os.path.join(current_dir, "..", "schemas", local_filename)
-        )
+        schema_content = None
+        source = ""
 
+        # 2. Dynamic Path Calculation (Works for both profiles)
+        # Assumes: profiles/profile.py and schemas/file.yaml are siblings
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        local_yaml_path = os.path.normpath(os.path.join(current_dir, "..", "schemas", local_filename))
+
+        # 3. Try Local File
         try:
             if os.path.exists(local_yaml_path):
                 sv = SchemaView(local_yaml_path, merge_imports=True)
                 _SCHEMA_VIEW_CACHE[schema_name] = sv
-                log.info(f"Schema '{schema_name}' loaded from local file: {local_yaml_path}")
+                log.info(f"Schema '{schema_name}' loaded from local file and cached: {local_yaml_path}")
                 return sv
         except Exception as e:
             log.error(f"Failed to parse local schema '{schema_name}' at {local_yaml_path}: {e}")
 
-        try:
-            log.debug(f"Loading schema '{schema_name}' from PURL: {purl}")
-            sv = SchemaView(purl, merge_imports=True)
-            _SCHEMA_VIEW_CACHE[schema_name] = sv
-            log.info(f"Schema '{schema_name}' loaded from remote PURL.")
-            return sv
-        except Exception as e:
-            log.error(f"Failed to parse schema '{schema_name}' from PURL {purl}: {e}")
-            return None
+        # 4. Try Remote PURL
+        if not schema_content:
+            try:
+                log.debug(f"Fetching schema '{schema_name}' from PURL: {purl}")
+                resp = requests.get(purl, headers={"Accept": "application/yaml, text/yaml"}, timeout=10)
+                resp.raise_for_status()
+                schema_content = resp.text
+                source = "remote PURL"
+            except Exception as e:
+                log.error(f"Failed to fetch schema '{schema_name}' from remote: {e}")
+                return None
+
+        # 5. Parse and Cache
+        if schema_content:
+            tmp_path = None
+            try:
+                # LinkML Runtime 1.4.0 expects SchemaView input to be a file path,
+                # not raw YAML content. Write remote schema content to a temp file.
+                fd, tmp_path = tempfile.mkstemp(
+                    prefix="%s_" % schema_name,
+                    suffix=".yaml"
+                )
+                with os.fdopen(fd, "w") as fh:
+                    fh.write(schema_content)
+
+                sv = SchemaView(tmp_path, merge_imports=True)
+                _SCHEMA_VIEW_CACHE[schema_name] = sv
+                log.info(f"Schema '{schema_name}' loaded from {source} and cached.")
+                return sv
+            except Exception as e:
+                log.error(f"Failed to parse schema '{schema_name}': {e}")
+                return None
+            finally:
+                if tmp_path and os.path.exists(tmp_path):
+                    try:
+                        os.remove(tmp_path)
+                    except Exception:
+                        pass
+
+        return None
 
     def _get_pubchem_cid(self, inchi_key=None, smiles=None):
         """

--- a/ckanext/dcat/profiles/dcat_ap_plus.py
+++ b/ckanext/dcat/profiles/dcat_ap_plus.py
@@ -1,6 +1,7 @@
 import json
 import os
 import tempfile
+import shutil
 from decimal import Decimal, DecimalException
 import requests
 from rdflib import term, URIRef, BNode, Literal, Graph
@@ -234,6 +235,15 @@ class Helpers(object):
                     prefix="%s_" % schema_name,
                     suffix=".yaml"
                 )
+
+                schema_content = _strip_linkml_18_keywords_for_linkml_14(schema_content)
+
+                # Avoid remote latest imports when running with linkml-runtime==1.4.0
+                schema_content = schema_content.replace(
+                    "- dcatapplus:latest/schema/dcat_ap_plus",
+                    "- dcat_ap_plus"
+                )
+
                 with os.fdopen(fd, "w") as fh:
                     fh.write(schema_content)
 

--- a/ckanext/dcat/profiles/dcat_ap_plus.py
+++ b/ckanext/dcat/profiles/dcat_ap_plus.py
@@ -84,6 +84,13 @@ def _strip_linkml_18_keywords_for_linkml_14(yaml_text):
     """
     unsupported_keys = set([
         "implements",
+        "bindings",
+        "equals_expression",
+        "exact_mappings",
+        "close_mappings",
+        "narrow_mappings",
+        "broad_mappings",
+        "related_mappings",
     ])
 
     lines = yaml_text.splitlines(True)

--- a/ckanext/dcat/profiles/dcat_ap_plus.py
+++ b/ckanext/dcat/profiles/dcat_ap_plus.py
@@ -73,8 +73,14 @@ def _strip_linkml_18_keywords_for_linkml_14(yaml_text):
     LinkML Runtime 1.4.0 does not support some newer LinkML keywords
     used by current DCAT-AP+ / ChemDCAT-AP schemas.
 
-    This strips unsupported keys while keeping the rest of the YAML,
-    including comments, unchanged as much as possible.
+    This removes unsupported YAML blocks such as:
+
+        implements:
+          - owl:NamedIndividual
+
+    and also inline forms such as:
+
+        implements: [owl:NamedIndividual]
     """
     unsupported_keys = set([
         "implements",
@@ -82,38 +88,48 @@ def _strip_linkml_18_keywords_for_linkml_14(yaml_text):
 
     lines = yaml_text.splitlines(True)
     cleaned = []
+    skip_block = False
     skip_indent = None
 
     for line in lines:
         stripped = line.lstrip()
 
+        # Keep blank lines/comments unless we are inside a skipped block
         if not stripped or stripped.startswith("#"):
-            if skip_indent is None:
+            if not skip_block:
                 cleaned.append(line)
             continue
 
         indent = len(line) - len(stripped)
 
-        if skip_indent is not None:
-            if indent > skip_indent:
+        if skip_block:
+            # Continue skipping child lines of the unsupported key.
+            # Also skip YAML list items at the same indentation, e.g.
+            # implements:
+            # - owl:NamedIndividual
+            if indent > skip_indent or (indent >= skip_indent and stripped.startswith("-")):
                 continue
+
+            # We reached the next normal YAML key/block.
+            skip_block = False
             skip_indent = None
 
-        key = stripped.split(":", 1)[0].strip()
+        if ":" in stripped:
+            key = stripped.split(":", 1)[0].strip()
+            value_after_colon = stripped.split(":", 1)[1].strip()
 
-        if key in unsupported_keys and ":" in stripped:
-            after_colon = stripped.split(":", 1)[1].strip()
+            if key in unsupported_keys:
+                # Inline case:
+                # implements: [owl:NamedIndividual]
+                if value_after_colon:
+                    continue
 
-            # Case 1:
-            # implements: [owl:NamedIndividual]
-            if after_colon:
+                # Block case:
+                # implements:
+                #   - owl:NamedIndividual
+                skip_block = True
+                skip_indent = indent
                 continue
-
-            # Case 2:
-            # implements:
-            #   - owl:NamedIndividual
-            skip_indent = indent
-            continue
 
         cleaned.append(line)
 

--- a/ckanext/dcat/profiles/dcat_ap_plus.py
+++ b/ckanext/dcat/profiles/dcat_ap_plus.py
@@ -93,52 +93,32 @@ class Helpers(object):
 
         Returns: SchemaView instance or None
         """
-        # 1. Check Memory Cache
         if schema_name in _SCHEMA_VIEW_CACHE:
             return _SCHEMA_VIEW_CACHE[schema_name]
 
-        schema_content = None
-        source = ""
-
-        # 2. Dynamic Path Calculation (Works for both profiles)
-        # Assumes: profiles/profile.py and schemas/file.yaml are siblings
         current_dir = os.path.dirname(os.path.abspath(__file__))
-        local_yaml_path = os.path.normpath(os.path.join(current_dir, "..", "schemas", local_filename))
+        local_yaml_path = os.path.normpath(
+            os.path.join(current_dir, "..", "schemas", local_filename)
+        )
 
-        # 3. Try Local File
         try:
             if os.path.exists(local_yaml_path):
                 sv = SchemaView(local_yaml_path, merge_imports=True)
                 _SCHEMA_VIEW_CACHE[schema_name] = sv
-                log.info(f"Schema '{schema_name}' loaded from local file and cached: {local_yaml_path}")
+                log.info(f"Schema '{schema_name}' loaded from local file: {local_yaml_path}")
                 return sv
         except Exception as e:
             log.error(f"Failed to parse local schema '{schema_name}' at {local_yaml_path}: {e}")
 
-        # 4. Try Remote PURL
-        if not schema_content:
-            try:
-                log.debug(f"Fetching schema '{schema_name}' from PURL: {purl}")
-                resp = requests.get(purl, headers={"Accept": "application/yaml, text/yaml"}, timeout=10)
-                resp.raise_for_status()
-                schema_content = resp.text
-                source = "remote PURL"
-            except Exception as e:
-                log.error(f"Failed to fetch schema '{schema_name}' from remote: {e}")
-                return None
-
-        # 5. Parse and Cache
-        if schema_content:
-            try:
-                sv = SchemaView(schema_content, merge_imports=True)
-                _SCHEMA_VIEW_CACHE[schema_name] = sv
-                log.info(f"Schema '{schema_name}' loaded from {source} and cached.")
-                return sv
-            except Exception as e:
-                log.error(f"Failed to parse schema '{schema_name}': {e}")
-                return None
-
-        return None
+        try:
+            log.debug(f"Loading schema '{schema_name}' from PURL: {purl}")
+            sv = SchemaView(purl, merge_imports=True)
+            _SCHEMA_VIEW_CACHE[schema_name] = sv
+            log.info(f"Schema '{schema_name}' loaded from remote PURL.")
+            return sv
+        except Exception as e:
+            log.error(f"Failed to parse schema '{schema_name}' from PURL {purl}: {e}")
+            return None
 
     def _get_pubchem_cid(self, inchi_key=None, smiles=None):
         """

--- a/ckanext/dcat/profiles/dcat_ap_plus.py
+++ b/ckanext/dcat/profiles/dcat_ap_plus.py
@@ -67,7 +67,95 @@ from linkml_runtime.utils.schemaview import SchemaView
 # Module-level cache for SchemaView instances
 # Key: schema_name, Value: SchemaView object
 _SCHEMA_VIEW_CACHE = {}
+def _strip_linkml_18_keywords_for_linkml_14(yaml_text):
+    """
+    LinkML Runtime 1.4.0 does not support some newer LinkML keywords
+    used by current DCAT-AP+ / ChemDCAT-AP schemas.
 
+    This strips unsupported keys while keeping the rest of the YAML,
+    including comments, unchanged as much as possible.
+    """
+    unsupported_keys = set([
+        "implements",
+    ])
+
+    lines = yaml_text.splitlines(True)
+    cleaned = []
+    skip_indent = None
+
+    for line in lines:
+        stripped = line.lstrip()
+
+        if not stripped or stripped.startswith("#"):
+            if skip_indent is None:
+                cleaned.append(line)
+            continue
+
+        indent = len(line) - len(stripped)
+
+        if skip_indent is not None:
+            if indent > skip_indent:
+                continue
+            skip_indent = None
+
+        key = stripped.split(":", 1)[0].strip()
+
+        if key in unsupported_keys and ":" in stripped:
+            after_colon = stripped.split(":", 1)[1].strip()
+
+            # Case 1:
+            # implements: [owl:NamedIndividual]
+            if after_colon:
+                continue
+
+            # Case 2:
+            # implements:
+            #   - owl:NamedIndividual
+            skip_indent = indent
+            continue
+
+        cleaned.append(line)
+
+    return "".join(cleaned)
+
+
+def _prepare_linkml_14_schema_dir(schema_dir):
+    """
+    Create a temporary sanitized copy of ckanext/dcat/schemas for
+    linkml-runtime==1.4.0.
+
+    It removes unsupported newer LinkML keywords from all YAML files.
+    It also rewrites the remote dcat_ap_plus import to the local schema
+    file, so LinkML 1.4.0 does not fetch a newer incompatible remote schema.
+    """
+    tmp_dir = tempfile.mkdtemp(prefix="ckanext_dcat_linkml14_")
+    tmp_schema_dir = os.path.join(tmp_dir, "schemas")
+
+    shutil.copytree(schema_dir, tmp_schema_dir)
+
+    for root, dirs, files in os.walk(tmp_schema_dir):
+        for filename in files:
+            if not filename.endswith((".yaml", ".yml")):
+                continue
+
+            path = os.path.join(root, filename)
+
+            with open(path, "r") as fh:
+                text = fh.read()
+
+            text = _strip_linkml_18_keywords_for_linkml_14(text)
+
+            # Make ChemDCAT-AP use the local sanitized dcat_ap_plus.yaml
+            # instead of the remote latest schema.
+            text = text.replace(
+                "- dcatapplus:latest/schema/dcat_ap_plus",
+                "- dcat_ap_plus"
+            )
+
+            with open(path, "w") as fh:
+                fh.write(text)
+
+    return tmp_dir, tmp_schema_dir
 
 class Helpers(object):
     """
@@ -109,9 +197,17 @@ class Helpers(object):
         # 3. Try Local File
         try:
             if os.path.exists(local_yaml_path):
-                sv = SchemaView(local_yaml_path, merge_imports=True)
+                schema_dir = os.path.dirname(local_yaml_path)
+                tmp_root, tmp_schema_dir = _prepare_linkml_14_schema_dir(schema_dir)
+                sanitized_yaml_path = os.path.join(tmp_schema_dir, local_filename)
+
+                sv = SchemaView(sanitized_yaml_path, merge_imports=True)
                 _SCHEMA_VIEW_CACHE[schema_name] = sv
-                log.info(f"Schema '{schema_name}' loaded from local file and cached: {local_yaml_path}")
+                log.info(
+                    "Schema '%s' loaded from sanitized local file and cached: %s",
+                    schema_name,
+                    sanitized_yaml_path
+                )
                 return sv
         except Exception as e:
             log.error(f"Failed to parse local schema '{schema_name}' at {local_yaml_path}: {e}")


### PR DESCRIPTION
This PR brings the production-tested test-server changes into master.

Production currently runs CKAN 2.9, Python 3.7, and linkml-runtime==1.4.0.
Current DCAT-AP+ / ChemDCAT-AP schemas use newer LinkML keywords such as
implements and bindings, which are not supported by LinkML Runtime 1.4.0.

The fix adds a compatibility layer in dcat_ap_plus.py that creates a temporary
sanitized schema copy at runtime, removes unsupported keys, and loads the
sanitized schema with SchemaView.

Tested on production branch test-server.
Working production commit: c5a7c5f16761bad86c240d3c1eb6299949fb624c